### PR TITLE
Check for exact system name before partial match checks

### DIFF
--- a/lib/sysrev/sysrevMeta.js
+++ b/lib/sysrev/sysrevMeta.js
@@ -118,8 +118,9 @@ module.exports = function(options) {
   /**
    * convert identifier into full system guid using:
    * 1) exact match on key
-   * 2) partial match on key
-   * 3) partial match on name
+   * 2) exact match on name
+   * 3) partial match on key
+   * 4) partial match on name
    */
   var findSystem = function(identifier) {
     identifier = identifier.replace(/[.+]/g, function(match) {
@@ -129,12 +130,20 @@ module.exports = function(options) {
     var re = new RegExp('^' + identifier + '.*', ['i']);
     var systemId;
 
+    // first try to find an exact match on key
     systemId = _.find(_.keys(_systems), function(system) { return system === identifier; });
 
+    // find exact match on name
+    if (!systemId) {
+      systemId = _.find(_.keys(_systems), function(system) { return _systems[system].name === identifier; });
+    }
+
+    // partial match on key
     if (!systemId) {
       systemId = _.find(_.keys(_systems), function(system) { return re.test(system); });
     }
 
+    // partial match on name
     if (!systemId) {
       systemId = _.find(_.keys(_systems), function(system) { return re.test(_systems[system].name); });
     }


### PR DESCRIPTION
Fixes #9 by adding check for exact system name before partial match checks